### PR TITLE
Comb returns json for zomecall and not stringified responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,14 +74,7 @@ class Connection extends EventEmitter {
     async zomeCall ( ...args ) {
 	let result;
 	const response			= await this.child.call("zomeCall", ...args );
-
-	try {
-	    result			= JSON.parse( response );
-	} catch (err) {
-	    console.error( err );
-	}
-
-	return result;
+	return response;
     }
 
     async signUp () {

--- a/tests/mock_comb.js
+++ b/tests/mock_comb.js
@@ -19,9 +19,6 @@ global.COMB = {
 
 module.exports = {
     nextResponse ( value ) {
-	if ( typeof value !== "string" )
-	    value				= JSON.stringify( value );
-
-	next_response				= value;
+	     next_response				= value;
     }
 }


### PR DESCRIPTION
@mjbrisebois It seems like results of zomeCalls in COMB are returned a json object.