### PR TITLE
B-03729 - implement data-translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `.zomeCall`, `.appInfo`, `.signUp`, `.signIn`, and `.signOut` all now expect to recieve a (data-translator)[https://www.npmjs.com/package/@holo-host/data-translator] packed message, and unpack it and return the payload or throw the error.
 
 ## [0.3.1] - 2021-02-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- `.zomeCall`, `.appInfo`, `.signUp`, `.signIn`, and `.signOut` all now expect to recieve a (data-translator)[https://www.npmjs.com/package/@holo-host/data-translator] packed message, and unpack it and return the payload or throw the error.
+- `.zomeCall`, `.appInfo`, `.signUp`, `.signIn`, and `.signOut` all now expect to receive a [data-translator](https://www.npmjs.com/package/@holo-host/data-translator) packed message, and unpack it and return the payload or throw the error.
 
 ## [0.3.1] - 2021-02-04
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   ],
   "dependencies": {
     "@holo-host/chaperone": "^0.2.2",
-    "@holo-host/comb": "^0.2.0"
+    "@holo-host/comb": "^0.2.0",
+    "@holo-host/data-translator": "^0.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,16 @@ if (!TESTING)
   COMB = require('@holo-host/comb').COMB;
 
 const { EventEmitter } = require('events');
+const { parse } = require("@holo-host/data-translator");
+
+function unpackData (message) {
+  const payload = parse(message).value()
+  if (payload instanceof Error) {
+    throw payload
+  }
+
+  return payload
+}
 
 class Connection extends EventEmitter {
 
@@ -74,30 +84,30 @@ class Connection extends EventEmitter {
 
   async zomeCall(...args) {
     const response = await this.child.call("zomeCall", ...args);
-    return response;
+    return unpackData(response);
   }
 
   async appInfo(...args) {
     const response = await this.child.call("appInfo", ...args);
-    return response;
+    return unpackData(response);
   }
 
   async signUp() {
     this.iframe.style.display = "block";
     const result = await this.child.call("signUp");
     this.iframe.style.display = "none";
-    return result;
+    return unpackData(result);
   }
 
   async signIn() {
     this.iframe.style.display = "block";
     const result = await this.child.call("signIn");
     this.iframe.style.display = "none";
-    return result;
+    return unpackData(result);
   }
 
   async signOut() {
-    return await this.child.run("signOut");
+    return unpackData(await this.child.run("signOut"));
   }
 }
 

--- a/tests/unit/test_api.js
+++ b/tests/unit/test_api.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { Package } = require("@holo-host/data-translator");
 const log = require('@whi/stdlog')(path.basename(__filename), {
   level: process.env.LOG_LEVEL || 'fatal',
 });
@@ -9,13 +10,16 @@ require("../mock_browser.js");
 const mock_comb = require("../mock_comb.js");
 const { Connection } = require("../../src/index.js");
 
+function packData (payload) {
+  return new Package(payload).toString()
+}
 
 describe("Javascript API", () => {
   it("should call zome function", async () => {
     const envoy = new Connection();
     await envoy.ready();
 
-    mock_comb.nextResponse({
+    mock_comb.nextResponse(packData({
       "Ok": {
         "balance": "0",
         "credit": "0",
@@ -24,7 +28,7 @@ describe("Javascript API", () => {
         "fees": "0",
         "available": "0",
       }
-    });
+    }));
 
     const response = await envoy.zomeCall(
       "holofuel", "transactions", "ledger_state"
@@ -49,14 +53,14 @@ describe("Javascript API", () => {
       cell_data: [[['hash', 'pubkey'], 'dna_alias']]
     };
 
-    mock_comb.nextResponse(expectedResponse);
+    mock_comb.nextResponse(packData(expectedResponse));
 
     const response = await envoy.appInfo(installed_app_id);
 
     log.debug("Response: %s", response);
 
     expect(response).to.be.an("object");
-    expect(response).to.equal(expectedResponse)
+    expect(response).to.deep.equal(expectedResponse)
   });
 
   describe('constructor', () => {


### PR DESCRIPTION
Implements data translator.

 `.zomeCall`, `.appInfo`, `.signUp`, `.signIn`, and `.signOut` all now expect to receive a [data-translator](https://www.npmjs.com/package/@holo-host/data-translator) packed message, and unpack it and return the payload or throw the error.