### PR TITLE
add holoInfo method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `holoInfo` method to get host url from `chaperone` [(#34)][]
+
+[(#34)]: https://github.com/Holo-Host/web-sdk/pull/34
 
 ## [0.4.0] - 2021-03-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Call a zome function on the respective DNA instance.
 ### `.appInfo( installed_app_id ) -> Promise<any>`
 Calls appInfo on the conductor with the provided id.
 
+### `.holoInfo() -> Promise<any>`
+Returns `{
+  url: string
+}`
+
 ### `.signIn() -> Promise<boolean>`
 Trigger Chaperone's sign-in prompt.
 

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,10 @@ class Connection extends EventEmitter {
   async signOut() {
     return await this.child.run("signOut");
   }
+
+  async holoInfo() {
+    return await this.child.run("holoInfo");
+  }
 }
 
 Connection.AUTONOMOUS = 1;


### PR DESCRIPTION
adds - `holoInfo` method to get host url from `chaperone`

Depends on https://github.com/Holo-Host/chaperone/pull/133