### PR TITLE
Implement cancellable option and back button interception [B-04330]

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,17 @@ Returns `{
   url: string
 }`
 
-### `.signIn() -> Promise<boolean>`
+### `.signIn( opts? ) -> Promise<boolean>`
 Trigger Chaperone's sign-in prompt.
+
+If `opts.cancellable`, then the prompt can be exited to remain anonymous. Default = `true`.
 
 > **WARNING:** This will throw an error if the context is `Connection.AUTONOMOUS`.
 
-### `.signUp() -> Promise<boolean>`
+### `.signUp( opts? ) -> Promise<boolean>`
 Trigger Chaperone's sign-up prompt.
+
+If `opts.cancellable`, then the prompt can be exited to remain anonymous. Default = `true`.
 
 > **WARNING:** This will throw an error if the context is `Connection.AUTONOMOUS`.
 

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,14 @@ class Connection extends EventEmitter {
     style.top = "0";
     style.left = "0";
     style.display = "none";
+
+    window.addEventListener('popstate', (event) => {
+      if (event.state === "_web_sdk_shown") {
+        history.back()
+      } else {
+        this.iframe.style.display = "none"
+      }
+    })
   }
 
   async context() {
@@ -101,17 +109,37 @@ class Connection extends EventEmitter {
     return response;
   }
 
-  async signUp() {
+  async signUp(opts) {
+    const { cancellable = true } = opts || {}
+    if (cancellable) {
+      history.pushState("_web_sdk_shown", "")
+    }
     this.iframe.style.display = "block";
-    const result = await this.child.call("signUp");
-    this.iframe.style.display = "none";
+    const result = await this.child.call("signUp", opts);
+    if (cancellable) {
+      if (history.state === "_web_sdk_shown") {
+        history.back()
+      }
+    } else {
+      this.iframe.style.display = "none";
+    }
     return result;
   }
 
-  async signIn() {
+  async signIn(opts) {
+    const { cancellable = true } = opts || {}
+    if (cancellable) {
+      history.pushState("_web_sdk_shown", "")
+    }
     this.iframe.style.display = "block";
-    const result = await this.child.call("signIn");
-    this.iframe.style.display = "none";
+    const result = await this.child.call("signIn", opts);
+    if (cancellable) {
+      if (history.state === "_web_sdk_shown") {
+        history.back()
+      }
+    } else {
+      this.iframe.style.display = "none";
+    }
     return result;
   }
 


### PR DESCRIPTION
If cancellable = true is passed to `signIn` or `signUp`, makes the back button close the modal and prevents the forward button from doing anything afterwards.