### PR TITLE
Fix `.ready` so it doesn't throw if you get an 'available' event too soon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- No longer throws an error if `available` event is received before `.ready` is called.
+
 ## [0.6.0-prerelease] - 2022-02-11
 ### Removed
 - Removes `signalCB` param (is replaced with `signal` event)

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ const holo = await WebSdkApi.connect({
 
 ### `.ready() -> Promise<null>`
 Waits for the app to be ready.
-Asynchronous short-hand for available event.
+Asynchronous short-hand for `'available'` event.
 ```javascript
 .on('available', () => { fulfill() });
 ```
 
-### `.zomeCall( dna_handle, zome_name, function_name, args ) -> Promise<any>`
+### `.zomeCall( role_id, zome_name, function_name, args ) -> Promise<any>`
 
 Calls a zome function on the respective DNA instance.
 
@@ -129,7 +129,7 @@ type DisabledAppReason =
   | { user: null }
   | { error: string }
 
-type InstalledAppInfoStatus = 
+type InstalledAppInfoStatus =
   | { disabled: { reason: DisabledAppReason } }
   | { paused: { reason: { error: string } } }
   | { running: null }
@@ -151,5 +151,3 @@ type InstalledAppInfo = {
 - `available` - emitted when the connection to chaperone and envoy are opened and hosted app is ready for zome calls
 - `unavailable` - emitted when the ws connection to chaperone and/or envoy is closed
 - `unrecoverable-agent-state` - emitted when an unrecoverable error event is passed from chapeone
-
-

--- a/src/index.js
+++ b/src/index.js
@@ -10,13 +10,13 @@ function makeUrlAbsolute(url) {
 }
 
 /**
- * The `WebSdkApi` class is a wrapper around the COMB.js library that provides a JavaScript API for Holo-Hosted web apps to call Holochain. 
+ * The `WebSdkApi` class is a wrapper around the COMB.js library that provides a JavaScript API for Holo-Hosted web apps to call Holochain.
  * @param child - The child process connecting to Chaperone that is being monitored.
  */
 class WebSdkApi extends EventEmitter {
   constructor(child) {
     super();
-    this.available = null;
+    this.available = () => {}; // Starts as a no-op, overwritten as a resolve once .ready is called
     this.child = child;
     child.msg_bus.on("alert", (event, ...args) => this.emit(event));
     child.msg_bus.on("signal", signal => this.emit('signal', signal));
@@ -37,9 +37,9 @@ class WebSdkApi extends EventEmitter {
 
   /**
    * The `static connect` function is a helper function that connects to the Chaperone server and returns a WebSdkApi object
-   * @param [] 
+   * @param []
    * - chaperoneUrl: The URL of the Chaperone server.
-   * - authFormCustomization: The optional app customizations to display when authorizing the user 
+   * - authFormCustomization: The optional app customizations to display when authorizing the user
    * @returns The `connect` function returns a `WebSdkApi` object.
    */
   static connect = async ({ chaperoneUrl, authFormCustomization: authOpts } = {}) => {


### PR DESCRIPTION
Fixes an issue where web-sdk would throw an error if it received an `available` event before `.ready` was called