### PR TITLE
fix: run build on 'npm install'

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "npm run bundle",
     "bundle": "npx webpack --mode production --output-filename holo_hosting_web_sdk.js",
-    "test": "yarn jest"
+    "test": "yarn jest",
+    "prepublish": "npm run build"
   },
   "author": "Holo Ltd.",
   "contributors": [


### PR DESCRIPTION
Add a 'prepublish' script so that library is built when installed by downstream dependencies.