### PR TITLE
Forward expanded state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.6.12-prerelease] - 2023-06-08
+### Added
+- chaperone api version check, with error message for incompatible api version [(#97)]
+- event handlers and local state for `chaperone-state` and `ui-state` events [(#97)]
 
+### Changed
+- `client.agent` to `client.agentState` [(#97)]
+
+[(#97)]: https://github.com/Holo-Host/web-sdk/pull/97
 
 ## [0.6.11-prerelease] - 2023-04-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.12-prerelease] - 2023-06-08
+
 
 ## [0.6.11-prerelease] - 2023-04-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ const main = async () => {
   await client.signIn()
   
   // The credentials overlay is now visible to the user. Wait for them to sign in
-  while (client.agent.isAnonymous || !client.agent.isAvailable) {
+  while (client.agent.isAnonymous || !client.agentState.isAvailable) {
     await sleep(50)
     // Again, this while/sleep pattern is for demo only. See comment above about doing this using an event handler
   }
 
-  console.log(client.agent)
+  console.log(client.agentState)
   /*
   {
     "id": "uhCAkRr1W12kUrY7SlSfwUpH_eJOxQGTZrIQxTQaV5-7kkh15Ewwg",
@@ -240,11 +240,19 @@ interface WebSdk {
   agent: AgentState
   // The unique ID within the Holo Hosting network for the current hApp. 
   happId: string
-  // Emitted whenever any field of `this.agent` changes.
+  // Emitted whenever any field of `this.agentState` changes.
   //
   // The event passes one argument, the current value of `this.agent`.
   // It's possible for duplicate `agent-state` events to be emitted.
-  on(event: 'agent-state', callback: (agent: AgentState) => void): void
+  on(event: 'agent-state', callback: (agentState: AgentState) => void): void
+  // Emitted whenever the Chaperone UI becomes visible or hidden, and whenever the particular UI page shown changes.
+  //
+  // It's possible for duplicate `ui-state` events to be emitted.
+  on(event: 'ui-state', callback: (uiState: UIState) => void): void
+  // Emitted whenever either of the above events is emitted. This event is passed a combination of the above two values.
+  //
+  // It's possible for duplicate `chaperone-state` events to be emitted.
+  on(event: 'chaperone-state', callback: (chaperoneState: ChaperoneState) => void): void
   // Emitted whenever the DNA emits a signal.
   //
   // `callback` takes an object containing the payload and the hash of the DNA which emitted it.
@@ -276,6 +284,20 @@ type AgentState = {
   unrecoverableError: UnrecoverableError | undefined
   // The URL of the HoloPort that is hosting the current agent. Useful for debugging.
   hostUrl: string
+}
+
+export type UIState = {
+  // true when the Chaperone UI overlay is visible
+  isVisible: boolean,
+  // the particular Chaperone UI page that's displayed, or 'hidden'
+  uiMode: UIMode
+}
+
+export type UIMode = 'login' | 'signup' | 'hidden'
+
+export type ChaperoneState = {
+  agentState: AgentState,
+  uiState: UIState
 }
 
 type UnrecoverableError = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holo-host/web-sdk",
-  "version": "0.6.11-prerelease",
+  "version": "0.6.12-prerelease",
   "description": "Standard development kit for creating Web UIs that work with Holo Hosting.",
   "main": "dist/holo_hosting_web_sdk",
   "module": "dist/holo_hosting_web_sdk.js",
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@holo-host/comb": "^0.3.0",
-    "@holochain/client": "0.12.0"
+    "@holochain/client": "0.12.0",
+    "semver": "^7.5.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,25 +217,27 @@ export default WebSdkApi
 // This is a duplication of the type AgentState from Chaperone. There isn't a neat way to share the code directly without publishing these types as their own npm module, 
 // so make sure they're up to date
 
-export type ChaperoneAgentState = {
-  id: string,
-  is_anonymous: boolean,
-  host_url: string,
-  is_available: boolean,
-  unrecoverable_error: any,
-  should_show_form?: boolean
+export type AgentState = {
+  id: string
+  is_anonymous: boolean
+  host_url: string
+  is_available: boolean
+  unrecoverable_error: any
+}
+
+export type UIState = {
+  is_visible: boolean,
+  ui_type: UIType
+}
+
+export type UIType = 'hidden' | 'auth-form-visible'
+
+export type ChaperoneState = {
+  agentState: AgentState,
+  uiState: UIState
 }
 
 // DUPLICATION END
-
-export type AgentState = {
-  id: string,
-  isAnonymous: boolean,
-  hostUrl: string,
-  isAvailable: boolean,
-  unrecoverableError: any,
-  shouldShowForm?: boolean
-}
 
 type AuthFormCustomization = {
   // The name of the hosted hApp. Currently shows up as "appName Login"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,19 +10,6 @@ function makeUrlAbsolute (url) {
   return new URL(url, window.location.href).href
 }
 
-// We make sure to only expose camelCase properties to the UI
-const presentAgentState: (ChaperoneAgentState) => AgentState = agent_state => ({
-  id: agent_state.id,
-  isAnonymous: agent_state.is_anonymous,
-  isAvailable: agent_state.is_available,
-  unrecoverableError: agent_state.unrecoverable_error,
-  hostUrl: agent_state.host_url
-  // We're keeping shouldShowForm as an implementation detail
-  // until there's a use-case for reacting to it in a UI.
-  //
-  // shouldShowForm: agent_state.should_show_form
-})
-
 /**
  * A `WebSdkApi` is a connection to a Chaperone iframe containing Holo's client logic.
  * @param child - The child process connecting to Chaperone that is being monitored.
@@ -30,10 +17,12 @@ const presentAgentState: (ChaperoneAgentState) => AgentState = agent_state => ({
 class WebSdkApi implements AppAgentClient {
   // Private constructor. Use `connect` instead.
   #child: any;
-  agent: AgentState;
+  agentState: AgentState;
+  uiState: UIState;
+  chaperoneState: ChaperoneState;
   #iframe: any;
   happId: string;
-  #should_show_form: boolean;
+  #should_show_ui: boolean;
   #cancellable: boolean;
   #emitter = new Emittery();
   myPubKey: AgentPubKey;
@@ -41,10 +30,21 @@ class WebSdkApi implements AppAgentClient {
   constructor (child) {
     this.#child = child
     child.msg_bus.on('signal', (signal: AppSignal) => this.#emitter.emit('signal', signal))
-    child.msg_bus.on('agent-state', (agent_state: ChaperoneAgentState) => {
-      this._setShouldShowForm(agent_state.should_show_form)
-      this.agent = presentAgentState(agent_state)
-      this.#emitter.emit('agent-state', this.agent)
+
+    child.msg_bus.on('agent-state', (agent_state: AgentState) => {      
+      this.agentState = agent_state
+      this.#emitter.emit('agent-state', this.agentState)
+    })
+
+    child.msg_bus.on('ui-state', (ui_state: UIState) => {      
+      this.uiState = ui_state
+      this._setShouldShowUI(ui_state.isVisible)
+      this.#emitter.emit('ui-state', this.uiState)
+    })
+
+    child.msg_bus.on('chaperone-state', (chaperone_state: ChaperoneState) => {      
+      this.chaperoneState = chaperone_state
+      this.#emitter.emit('chaperone-state', this.chaperoneState)
     })
   }
 
@@ -126,7 +126,7 @@ class WebSdkApi implements AppAgentClient {
 
     // Chaperone either returns agent_state and happ_id (success case)
     // or error_message
-    const { error_message, agent_state, happ_id } = await child.call(
+    const { error_message, chaperone_state, happ_id } = await child.call(
       'handshake'
     )
     if (error_message) {
@@ -134,20 +134,24 @@ class WebSdkApi implements AppAgentClient {
       throw new Error(error_message)
     }
 
-    webSdkApi.agent = presentAgentState(agent_state)
+    const { agentState, uiState } = chaperone_state
+
+    webSdkApi.agentState = agentState
+    webSdkApi.uiState = uiState
+    webSdkApi.chaperoneState = chaperone_state
     webSdkApi.happId = happ_id
 
     return webSdkApi
   }
 
-  _setShouldShowForm = should_show_form => {
+  _setShouldShowUI = should_show_ui => {
     // Without this check, we call history.back() too many times and end up exiting the UI
-    if (this.#should_show_form === should_show_form) {
+    if (this.#should_show_ui === should_show_ui) {
       return
     }
 
-    this.#should_show_form = should_show_form
-    if (should_show_form) {
+    this.#should_show_ui = should_show_ui
+    if (should_show_ui) {
       if (this.#cancellable) {
         history.pushState('_web_sdk_shown', '')
       }
@@ -211,26 +215,24 @@ class WebSdkApi implements AppAgentClient {
 
 export default WebSdkApi
 
-
-
 // DUPLICATION START
 // This is a duplication of the type AgentState from Chaperone. There isn't a neat way to share the code directly without publishing these types as their own npm module, 
 // so make sure they're up to date
 
 export type AgentState = {
   id: string
-  is_anonymous: boolean
-  host_url: string
-  is_available: boolean
-  unrecoverable_error: any
+  isAnonymous: boolean
+  hostUrl: string
+  isAvailable: boolean
+  unrecoverableError: any
 }
 
 export type UIState = {
-  is_visible: boolean,
-  ui_type: UIType
+  isVisible: boolean,
+  uiMode: UIMode
 }
 
-export type UIType = 'hidden' | 'auth-form-visible'
+export type UIMode = 'login' | 'signup' | 'hidden'
 
 export type ChaperoneState = {
   agentState: AgentState,

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -16,7 +16,7 @@ describe('test API endpoints', () => {
 
   beforeEach(async () => {
     // Expected handshake response when successful is { happ_id, agent_state }
-    mock_comb.nextResponse({ happ_id: '', agent_state: {} })
+    mock_comb.nextResponse({ happ_id: '', chaperone_state: { agent_state: {}, ui_state: {} }, chaperone_version: `0.1.0` })
     holo = await WebSdkApi.connect({
       chaperoneUrl: ''
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4253,6 +4253,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
+  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serialize-javascript@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"


### PR DESCRIPTION
This PR forwards the  `ui-state` and `chaperone-state` events from the chaperone changes linked below.

This PR also adds a check for compatibility of chaperone version.

Goes with these changes to envoy-chaperone: https://github.com/Holo-Host/envoy-chaperone/pull/170